### PR TITLE
delete_ belongs_to :transaction

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,6 @@ class Item < ApplicationRecord
   belongs_to :shipping_region
   belongs_to :shipping_day
   belongs_to :shipping_burden
-  belongs_to :transaction
   belongs_to :buyer, class_name: 'User'
   belongs_to :saler, class_name: 'User'
   has_many :category_items, dependent: :destroy


### PR DESCRIPTION
#what
models/item.rbに残っているbelongs_to :transactionの削除
#why
未使用なアソシエーションの削除。本番環境エラー解消